### PR TITLE
Test fix

### DIFF
--- a/select.jsx
+++ b/select.jsx
@@ -26,7 +26,7 @@ export default class UnstructuredSelect extends Component {
       });
     }
     // if default value prop doesn't match the value of an option passed in raise an error
-    else if (!defaultValue || !this.props.options.find((option)=>{ return deepEqual(option.value, this.props.defaultValue)})) {
+    else if (!this.props.options.find((option)=>{ return deepEqual(option.value, this.props.defaultValue)})) {
       throw Error("Default value must be in options")
     }
     else {
@@ -41,7 +41,7 @@ export default class UnstructuredSelect extends Component {
   onChange(event){
     const value = this.state.options.find((option)=>{return option.index===event.target.value}).value
     this.setState({
-
+      value
     })
     this.props.onChange(value)
   }

--- a/select.test.jsx
+++ b/select.test.jsx
@@ -61,13 +61,14 @@ test('componentDidMount sets value to undefined if not passed a value', ()=>{
 });
 
 test('componentDidMount sets value to defaultValue from props if passed a value', ()=>{
-    const component = shallow(<UnstructuredSelect options={options} defaultValue={[1,2,3]}/>);
+    const defaultValue = ['cats', 'dogs']
+    const component = shallow(<UnstructuredSelect options={options} defaultValue={defaultValue}/>);
     component.instance().componentDidMount();
-    expect(component.state().value).toEqual([1, 2, 3]);
+    expect(component.state().value).toEqual(defaultValue);
 })
 
 test('componentDidMount throws an error if a default value is passed in that is not in the options passed in', ()=>{
-    const component = shallow(<UnstructuredSelect options={options}/>);
-    component.instance().componentDidMount();
-    expect(component.state().value).toEqual(undefined);
+    const defaultValue = { 'over': '9000' }
+    const component = shallow(<UnstructuredSelect defaultValue={defaultValue} options={options}/>, {disableLifecycleMethods:true});
+    expect(() => component.instance.componentDidMount()).toThrow();
 })  


### PR DESCRIPTION
componentDidMount sets value to defaultValue from props if passed a value: you need to pass a valid defaultValue, so it's included in the options.. otherwise componentDidMount throws, failing the test

componentDidMount throws an error if a default value is passed in that is not in the options passed in:
you need to pass invalid defaultValue prop (just not sending any defaultValue shouldn't and won't throw) and expect the render function to throw (note that we need to disable lifecycle methods as that would cause premature and uncaught throw)

onChange sets the value in state correctly: you were just forgetting to set the value

Hope this helps!